### PR TITLE
Nsheetz1

### DIFF
--- a/src/Perk.java
+++ b/src/Perk.java
@@ -1,17 +1,16 @@
-
 public enum Perk {
     
-    POWER(1,1.3,false,0.05,false,new int[]{1},Perks.tsFactor.POWER),
-    MOTIVATION(2,1.3,false,0.05,false,new int[]{1,2,3},Perks.tsFactor.MOTIVATION),
-    CARPENTRY(25,1.3,false,1.1,true,new int[]{1,2,3},Perks.tsFactor.CARPENTRY),
-    LOOTING(1,1.3,false,0.05,false,new int[]{1},Perks.tsFactor.LOOTING),   
-    POWER2(20000,500,true,0.01,false,new int[]{100,1000},Perks.tsFactor.POWER),
-    MOTIVATION2(50000,1000,true,0.01,false,new int[]{100,1000,2000,5000},Perks.tsFactor.MOTIVATION),
-    CARPENTRY2(100000,10000,true,0.0025,false,new int[]{100,1000,2000},Perks.tsFactor.CARPENTRY),
-    LOOTING2(100000,10000,true,0.0025,false,new int[]{100,1000},Perks.tsFactor.LOOTING),
-    COORDINATED(150000,1.3,false,0.98,true,new int[]{1},Perks.tsFactor.COORDINATED),
-    ARTISANISTRY(15,1.3,false,0.95,true,new int[]{1},Perks.tsFactor.ARTISANISTRY),
-    RESOURCEFUL(50000,1.3,false,0.95,true,new int[]{1,2,3},Perks.tsFactor.RESOURCEFUL);
+    POWER(1,1.3,false,0.05,false,new int[]{1}),
+    MOTIVATION(2,1.3,false,0.05,false,new int[]{1,2,3}),
+    CARPENTRY(25,1.3,false,1.1,true,new int[]{1,2,3}),
+    LOOTING(1,1.3,false,0.05,false,new int[]{1}),   
+    POWER2(20000,500,true,0.01,false,new int[]{100,1000}),
+    MOTIVATION2(50000,1000,true,0.01,false,new int[]{100,1000,2000,5000}),
+    CARPENTRY2(100000,10000,true,0.0025,false,new int[]{100,1000,2000}),
+    LOOTING2(100000,10000,true,0.0025,false,new int[]{100,1000}),
+    COORDINATED(150000,1.3,false,0.98,true,new int[]{1}),
+    ARTISANISTRY(15,1.3,false,0.95,true,new int[]{1}),
+    RESOURCEFUL(50000,1.3,false,0.95,true,new int[]{1,2,3});
   
     public final long baseCost;
     public final double scaleFactor;
@@ -19,18 +18,34 @@ public enum Perk {
     public final double effect;
     public final boolean compounding;
     public final int[] levelIncreases;
-    public final Perks.tsFactor tsFactor;
     
     Perk(final long baseCost,
     		final double scaleFactor, final boolean additive, 
     		final double effect, final boolean compounding,
-    		final int[] levelIncreases, final Perks.tsFactor tsFactor){
+    		final int[] levelIncreases){
         this.baseCost = baseCost;
         this.scaleFactor = scaleFactor;
         this.additive = additive;
         this.effect = effect;
         this.compounding = compounding;
         this.levelIncreases = levelIncreases;
-        this.tsFactor = tsFactor;
+    }
+    
+    // avoiding circular references between Perk and tsFactor constructors
+    public static Perks.tsFactor getTSFactor(Perk p) {
+    	switch (p) {
+    	case POWER: return Perks.tsFactor.POWER;
+    	case POWER2: return Perks.tsFactor.POWER;
+    	case MOTIVATION: return Perks.tsFactor.MOTIVATION;
+    	case MOTIVATION2: return Perks.tsFactor.MOTIVATION;
+    	case CARPENTRY: return Perks.tsFactor.CARPENTRY;
+    	case CARPENTRY2: return Perks.tsFactor.CARPENTRY;
+    	case LOOTING: return Perks.tsFactor.LOOTING;
+    	case LOOTING2: return Perks.tsFactor.LOOTING;
+    	case COORDINATED: return Perks.tsFactor.COORDINATED;
+    	case ARTISANISTRY: return Perks.tsFactor.ARTISANISTRY;
+    	case RESOURCEFUL: return Perks.tsFactor.RESOURCEFUL;
+    	default: return null;
+    	}
     }
 }

--- a/src/Perk.java
+++ b/src/Perk.java
@@ -1,27 +1,36 @@
 
 public enum Perk {
     
-    POWER(1,1.3,false,new int[]{1}),
-    MOTIVATION(2,1.3,false,new int[]{1,2,3}),
-    CARPENTRY(25,1.3,false,new int[]{1,2,3}),
-    LOOTING(1,1.3,false,new int[]{1}),   
-    POWER2(20000,500,true,new int[]{100,1000}),
-    MOTIVATION2(50000,1000,true,new int[]{100,1000,2000,5000}),
-    CARPENTRY2(100000,10000,true,new int[]{100,1000,2000}),
-    LOOTING2(100000,10000,true,new int[]{100,1000}),
-    COORDINATED(150000,1.3,false,new int[]{1}),
-    ARTISANISTRY(15,1.3,false,new int[]{1}),
-    RESOURCEFUL(50000,1.3,false,new int[]{1,2,3});
+    POWER(1,1.3,false,0.05,false,new int[]{1},Perks.tsFactor.POWER),
+    MOTIVATION(2,1.3,false,0.05,false,new int[]{1,2,3},Perks.tsFactor.MOTIVATION),
+    CARPENTRY(25,1.3,false,1.1,true,new int[]{1,2,3},Perks.tsFactor.CARPENTRY),
+    LOOTING(1,1.3,false,0.05,false,new int[]{1},Perks.tsFactor.LOOTING),   
+    POWER2(20000,500,true,0.01,false,new int[]{100,1000},Perks.tsFactor.POWER),
+    MOTIVATION2(50000,1000,true,0.01,false,new int[]{100,1000,2000,5000},Perks.tsFactor.MOTIVATION),
+    CARPENTRY2(100000,10000,true,0.0025,false,new int[]{100,1000,2000},Perks.tsFactor.CARPENTRY),
+    LOOTING2(100000,10000,true,0.0025,false,new int[]{100,1000},Perks.tsFactor.LOOTING),
+    COORDINATED(150000,1.3,false,0.98,true,new int[]{1},Perks.tsFactor.COORDINATED),
+    ARTISANISTRY(15,1.3,false,0.95,true,new int[]{1},Perks.tsFactor.ARTISANISTRY),
+    RESOURCEFUL(50000,1.3,false,0.95,true,new int[]{1,2,3},Perks.tsFactor.RESOURCEFUL);
   
     public final long baseCost;
     public final double scaleFactor;
     public final boolean additive;
+    public final double effect;
+    public final boolean compounding;
     public final int[] levelIncreases;
+    public final Perks.tsFactor tsFactor;
     
-    Perk(final long baseCost, final double scaleFactor, final boolean additive, final int[] levelIncreases){
+    Perk(final long baseCost,
+    		final double scaleFactor, final boolean additive, 
+    		final double effect, final boolean compounding,
+    		final int[] levelIncreases, final Perks.tsFactor tsFactor){
         this.baseCost = baseCost;
         this.scaleFactor = scaleFactor;
         this.additive = additive;
+        this.effect = effect;
+        this.compounding = compounding;
         this.levelIncreases = levelIncreases;
+        this.tsFactor = tsFactor;
     }
 }

--- a/src/Perks.java
+++ b/src/Perks.java
@@ -1,3 +1,5 @@
+import java.util.Comparator;
+import java.util.Arrays;
 
 public class Perks {
     private double totalHelium;
@@ -32,32 +34,6 @@ public class Perks {
         }
     }
     
-    public double perkCost(final Perk perk, final int amount){
-        if (perk.additive){
-            long base = perk.baseCost+((long)perk.scaleFactor*perks[perk.ordinal()]);
-            return ((base+(long)(perk.scaleFactor*(amount-1)/2))*amount);
-        }
-        else{
-            long total = 0;
-            int level = perks[perk.ordinal()];
-            for (int x = 1; x<=amount;x++){
-                total += perk.baseCost*Math.pow(perk.scaleFactor, level);
-                level++;
-            }
-            return total;
-        }
-    }
-    
-    public boolean buyPerk(final Perk perk, final int amount){
-        double cost = perkCost(perk,amount);
-        if (cost<=helium){
-            helium-=cost;
-            perks[perk.ordinal()]+=amount;
-            return true;
-        }
-        return false;
-    }
-    
     public int getLevel(final Perk perk){
         return perks[perk.ordinal()];
     }
@@ -68,5 +44,296 @@ public class Perks {
     
     public double getSpentHelium(){
         return totalHelium-helium;
+    }
+    
+    public double perkCost(final Perk perk, int amount) {
+    	int baseLevel;
+    	if (amount < 0) {
+    		amount = Math.min(-amount, getLevel(perk));
+    		baseLevel = perks[perk.ordinal()] - amount;
+    	} else {
+    		baseLevel = perks[perk.ordinal()];
+    	}
+        if (perk.additive){
+            double base = perk.baseCost+((double)perk.scaleFactor*baseLevel);
+            return ((base+(double)(perk.scaleFactor*(amount-1)/2d))*amount);
+        }
+        else{
+        	double base = perk.baseCost*Math.pow(perk.scaleFactor, baseLevel);
+        	// base cost times geometric sum for exponents of 1 -> amount
+            return base
+            		* (1 - Math.pow(perk.scaleFactor, amount))
+            		/ (1 - perk.scaleFactor);
+        }
+    }
+    
+    public boolean buyPerk(final Perk perk, int amount){
+        double cost = perkCost(perk,amount);
+        if (amount < 0) {
+        	// can't sell more levels of a perk than we have
+        	amount = Math.min(-amount, perks[perk.ordinal()]); 
+        	if (cost > 0) {
+        		helium += cost;
+        		perks[perk.ordinal()] -= amount;
+        		return true;
+        	} else {
+        		return false;
+        	}
+        } else {
+        	if (cost<=helium){
+        		helium-=cost;
+        		perks[perk.ordinal()]+=amount;
+        		return true;
+        	}
+        	return false;
+        }
+    }
+    
+    public enum tsFactor {
+    	POWER, MOTIVATION, CARPENTRY, LOOTING, COORDINATED, ARTISANISTRY, RESOURCEFUL;
+    }
+    public static final int numTSFactors = tsFactor.values().length;
+    
+    public double[] getTSFactors() {
+    	double[] res = new double[numTSFactors];
+        res[tsFactor.POWER.ordinal()] = (1 + Perk.POWER.effect * perks[Perk.POWER.ordinal()])
+				* (1 + Perk.POWER2.effect * perks[Perk.POWER2.ordinal()]);
+        res[tsFactor.MOTIVATION.ordinal()] = (1 + Perk.MOTIVATION.effect * perks[Perk.MOTIVATION.ordinal()])
+				* (1 + Perk.MOTIVATION2.effect * perks[Perk.MOTIVATION2.ordinal()]);	
+        res[tsFactor.CARPENTRY.ordinal()] = Math.pow(Perk.CARPENTRY.effect, perks[Perk.CARPENTRY.ordinal()])
+				* (1 + Perk.CARPENTRY2.effect * perks[Perk.CARPENTRY2.ordinal()]);
+        res[tsFactor.LOOTING.ordinal()] = (1 + Perk.LOOTING.effect * perks[Perk.LOOTING.ordinal()])
+				* (1 + Perk.LOOTING2.effect * perks[Perk.LOOTING2.ordinal()]);
+        res[tsFactor.COORDINATED.ordinal()] = (1 + 0.25 * Math.pow(Perk.COORDINATED.effect, perks[Perk.COORDINATED.ordinal()]));
+        res[tsFactor.ARTISANISTRY.ordinal()] = Math.pow(Perk.ARTISANISTRY.effect, perks[Perk.ARTISANISTRY.ordinal()]);
+        res[tsFactor.RESOURCEFUL.ordinal()] = Math.pow(Perk.RESOURCEFUL.effect, perks[Perk.RESOURCEFUL.ordinal()]);
+        return res;
+    }
+    
+    public static double calcCoordFactor(int level) {
+    	return (1 + 0.25 * Math.pow(.98, level));
+    }
+    
+    private class BuySellEfficiency {
+    	private double buyEfficiency;
+    	private double sellEfficiency;
+    	private Perk perk;
+    	private double rawEff;
+    	
+    	public BuySellEfficiency( Perk p, double rE ) {
+    		perk = p;
+    		rawEff = rE;
+    		calculateEfficiencies();
+    	}
+    	
+    	private void calculateEfficiencies() {
+    		buyEfficiency = getHeliumGainEfficiency(perk, rawEff, 1);
+    		sellEfficiency = getHeliumGainEfficiency(perk, rawEff, -1);
+    	}
+    	
+    	public Perk getPerk() {
+    		return perk;
+    	}
+    	
+    	public double getSellEfficiency() {
+    		return sellEfficiency;
+    	}
+    	
+    	public double getBuyEfficiency() {
+    		return buyEfficiency;
+    	}
+    	
+    	public boolean adjustPerk( int amount ) {
+    		if (buyPerk(perk, amount)) {
+    			calculateEfficiencies();
+    			return true;
+    		} else {
+    			calculateEfficiencies();
+    			return false;
+    		}
+    	}
+    }
+    
+    // sort in DESCENDING order of sell efficiency
+    private static Comparator<BuySellEfficiency> BuyComp = new Comparator<BuySellEfficiency>() {
+    	@Override
+    	public int compare(BuySellEfficiency a, BuySellEfficiency b) {
+    		return (a.buyEfficiency < b.buyEfficiency) ? 1 :
+    			(a.buyEfficiency == b.buyEfficiency) ? 0 : -1;
+    	}
+    };
+    
+    // sort in DESCENDING order of buy efficiency
+    private static Comparator<BuySellEfficiency> SellComp = new Comparator<BuySellEfficiency>() {
+    	@Override
+    	public int compare(BuySellEfficiency a, BuySellEfficiency b) {
+    		return (a.sellEfficiency < b.sellEfficiency) ? 1 :
+    			(a.sellEfficiency == b.sellEfficiency) ? 0 : -1;
+    	}
+    };
+   
+    // given a set of TrimpsSimulation factor efficiencies, guess a better set of perks
+    // return true if perks were changed, else false
+    public boolean permutePerks(double[] rawEffs) {
+    	
+    	// Use an array for efficient sorting by 2 different comparators (buy and sell efficiency)
+    	// -> The list is small, so the sort operation should be fast.
+    	//	The presumption is that the overhead of maintaining more complex collections (e.g. TreeSet)
+    	//	with different sorting orders, would be worse than just sorting the whole array
+    	//  each time we update an element.
+    	BuySellEfficiency[] bsEffs = new BuySellEfficiency[Perk.values().length];
+    	
+    	// compile the initial list of buy/sell efficiencies (unsorted)
+    	for ( Perk p : Perk.values() ) {
+    		bsEffs[p.ordinal()] = new BuySellEfficiency(p, rawEffs[p.ordinal()]);
+    	}
+	
+
+		// sell least-efficient perks until we are sure none are over-bought (see method for further description)
+    	// -> no need to track whether we did anything, because if we did,
+    	//	then buyMostEfficientPerks will do something and return true
+		sellLeastEfficientPerks(bsEffs);
+	
+		//System.out.format("perks after sell: %s%n", Arrays.toString(perks));
+	
+		// then buy most-efficient perks until we run out of helium
+		return buyMostEfficientPerks(bsEffs);
+    }
+    
+    private void sellLeastEfficientPerks(BuySellEfficiency[] bsEffs) {
+    	// sort the list by sell efficiency
+    	Arrays.sort(bsEffs, SellComp);
+    	// get the most efficient perk at the beginning (which we know we don't want to sell)
+    	double efficiencyToSell = bsEffs[0].getSellEfficiency();
+    	// sell all other perks until they are more efficient than the above
+    	for ( int i = 1; i < bsEffs.length; i++ ) {
+    		BuySellEfficiency bse = bsEffs[i];
+    		while (bse.getSellEfficiency() < efficiencyToSell) {
+    			//System.out.format("sell perk %s to eff=%.4e: curEff=%.4e%n",
+    			//		bse.perk.name(), efficiencyToSell, bse.getSellEfficiency());
+    			// TODO? sell more than 1 level at once
+    			bse.adjustPerk(-1);
+    		}
+    	}
+    }
+    
+    private boolean buyMostEfficientPerks(BuySellEfficiency[] bsEffs) {
+    	boolean res = false;
+    	
+    	// sort the list by buy efficiency
+    	Arrays.sort(bsEffs, BuyComp);
+    	
+    	// loop until no perk is affordable
+    	while (bsEffs[0].getBuyEfficiency() > 0) {
+    		double nextEfficiency = bsEffs[1].getBuyEfficiency();
+    		// loop buying this perk until it's no longer the most efficient
+    		while (bsEffs[0].getBuyEfficiency() >= nextEfficiency && bsEffs[0].adjustPerk(1)) {
+    			res = true;
+    		}
+//    		System.out.format("adjusted perk %s to lev=%d eff=%.4e%n",
+//    				bsEffs[0].getPerk(), perks[bsEffs[0].getPerk().ordinal()],
+//    				bsEffs[0].getBuyEfficiency());
+    		// re-sort this perk
+    		// TODO? we know the rest of the array is sorted, so we can do an O(n) sort if needed
+    		// -> but note that O(n * log(#perks)) is already good, so you'd better do a really good job!
+    		Arrays.sort(bsEffs, BuyComp);
+    	}
+    	
+    	return res;
+    }
+    
+    // get efficiency of he/hr gain for helium cost gain, normalized to totalHelium
+    // -> This way efficiencies are stable with changes in spent helium,
+    //	and the "true" efficiency (relative to spent helium) converges to
+    //	the calculated efficiency as spent helium converges to total helium.
+    private double getHeliumGainEfficiency(Perk perk, double rawEff, int amount) {
+    	int baseLevel = perks[perk.ordinal()];
+    	double cost = perkCost(perk, amount);
+    	if (amount < 0) {
+    		if (baseLevel == 0) {
+    			// return infinite efficiency if we can't sell the requested perk
+    			return Double.POSITIVE_INFINITY;
+    		}
+    		// set sell amount to actual number of levels that can be sold
+    		amount = Math.min(-amount, baseLevel);
+    		baseLevel -= amount;
+    	} else if (amount == 0 || cost > helium) {
+    		// return 0 efficiency if we can't afford the requested amount
+    		return 0;
+    	}
+    	// transform cost to log on scale of total helium
+    	cost = Math.log(1 + cost / totalHelium);
+    	if (perk == Perk.COORDINATED) {
+    		// the rawEff for coordinated is the hehr gain from 1 more point
+    		return amount * Math.log(rawEff) / cost;
+    	} else if (perk.compounding) {
+    		// for compounding perks that provide a discount, the benefit is the reciprocal of the effect
+    		double effect = perk.effect < 1 ? 1/perk.effect : perk.effect;
+    		// for all compounding perks, the benefit is just multiplied by the number of levels
+    		return rawEff * amount * Math.log(effect) / cost;
+    	} else {
+    		// for additive perks, the effect diminishes with increasing levels
+    		double effect = 1 + amount / (1/perk.effect + baseLevel);
+    		return rawEff * Math.log(effect) / cost;
+    	}
+    }
+    
+    // todo: consider junking this. can just treat base/spire perks separately, using same tsFactor.
+    // buy specified levels of spire perk, including buying the base perk
+    public boolean buySpirePerk(final Perk perk, int amount) {
+    	double aBase = 0;
+    	double fBase = 1;
+    	double aSpire = 0;
+    	Perk perkB;
+    	switch (perk) {
+    		case POWER2:
+    			perkB = Perk.POWER;
+    			aBase = 0.05;
+    			aSpire = 0.01;
+    			break;
+    		case MOTIVATION2:
+    			perkB = Perk.MOTIVATION;
+    			aBase = 0.05;
+    			aSpire = 0.01;
+    			break;
+    		case LOOTING2:
+    			perkB = Perk.LOOTING;
+    			aBase = 0.05;
+    			aSpire = 0.0025;
+    			break;
+    		case CARPENTRY2:
+    			perkB = Perk.CARPENTRY;
+    			fBase = 1.1;
+    			aSpire = 0.0025;
+    			break;
+    		default:
+    			throw new Error("perk " + perk.name() + " is not a Spire perk!%n");
+    	}
+    	
+    	boolean baseMaxed = false;
+    	do {
+    		if (baseMaxed) {
+    			return buyPerk(perk, amount);
+    		}
+    		
+    		// calculate efficiency (in gain amount per helium) for base perk
+    		int lBase = perks[perkB.ordinal()];
+    		double cBase = perkCost(perkB, 1);
+    		double eBase = (fBase * (1 + 1/(1/aBase + lBase)) - 1)/cBase;
+    	
+    		// calculate efficiency for spire perk
+    		int lSpire = perks[perk.ordinal()];
+    		double cSpire = perkCost(perk, 1); 
+    		double eSpire = 1/(1/aSpire + lSpire)/cSpire;
+    		
+    		if (eBase >= eSpire) {
+    			if (!buyPerk(perkB, 1)) { baseMaxed = true; }
+    		} else {
+    			int toBuy = (int) Math.min(amount, Math.max(1, (Math.sqrt(eSpire / eBase) - 1) * lBase));
+    			if (!buyPerk(perk, toBuy)) { return false; }
+    			amount -= toBuy;
+    		}
+    	} while (amount > 0);
+    	return true;
     }
 }

--- a/src/Perks.java
+++ b/src/Perks.java
@@ -47,6 +47,10 @@ public class Perks {
         return totalHelium-helium;
     }
     
+    public double getTotalHelium() {
+    	return totalHelium;
+    }
+    
     public double perkCost(final Perk perk, int amount) {
     	int baseLevel;
     	if (amount < 0) {

--- a/src/SimulationResult.java
+++ b/src/SimulationResult.java
@@ -4,6 +4,9 @@ public class SimulationResult {
      public final double hours;
      public final int zone;
      
+     public double getHehr() {
+    	 return helium / hours;
+     }
 
      public SimulationResult(final double helium, final double hours, final int zone){
          this.helium = helium;

--- a/src/TrimpsSimulation.java
+++ b/src/TrimpsSimulation.java
@@ -5,16 +5,16 @@ import java.util.List;
 
 public class TrimpsSimulation {
 
-    public final static int goldenFrequency = 30;
-    public final static int blacksmitheryZone = 284;
+	public final static int goldenFrequency = 30;
+    public final static int blacksmitheryZone = 299;
     public final static double critChance = 0.726;
     public final static double critDamage = 13.7;
     public final static double cellDelay = 0.4;
     public final static double attackDelay = 0.258;
     public final static double okFactor = 0.15;
-    public final static double achievementDamage = 13.577;
+    public final static double achievementDamage = 14.352;
     public final static double heirloomDamage = 5.7;
-    public final static double robotrimpDamage = 7;
+    public final static double robotrimpDamage = 7.6;
     public final static double heirloomMetalDrop = 6.04;
     public final static double heirloomMinerEff = 6.12;
     public final static int corruptionStart = 151;
@@ -24,9 +24,9 @@ public class TrimpsSimulation {
     public final static double mapSize = 26;
     public final static double dropsPerMap = mapSize / 2d / 3d; // garden drop (1/3 metal) on 1/2 cells
     public final static double minerFraction = 0.99;
-    public final static double armorFraction = 0.01; // fraction of metal spent on armor
     public final static int packrat = 40;
-    public final static boolean optimizeMaps = true; // true=optimize maps by doing test sims, false=use fixed grid based on damageFactor
+    public final static boolean optimizeMaps = false; // true=optimize maps by doing test sims, false=use fixed grid based on damageFactor
+    public final static double armorFraction = 0.01; // fraction of metal spent on armor
     private final static double[] mapOffsets = new double[] { 100, 0.75, 0.5,
             0.2, 0.13, 0.08, 0.05, 0.036, 0.03, 0.0275 };
     private final boolean useCache;
@@ -55,6 +55,7 @@ public class TrimpsSimulation {
     private EquipmentManager eM;
     private PopulationManager pM;
     private ZoneSimulation zoneSimulation;
+    private int debug = 0;
     
     // expected dodges per hit for dodge imps
     private final static int dodgeLength = 20;
@@ -76,6 +77,11 @@ public class TrimpsSimulation {
     }
 
     public SimulationResult runSimulation() {
+    	return runSimulation(debug);
+    }
+    
+    public SimulationResult runSimulation(int debug) {
+    	this.debug = debug;
         double highestHeHr = 0;
         while (true) {
             startZone();
@@ -234,7 +240,9 @@ public class TrimpsSimulation {
 	        }
 	        time += bestTime;
 	        addProduction(bestZoneTime, dropsPerZone, 1);
-	        //System.out.format("Zone %d, ran %d maps, total time %.2f, dF=%.3f%n", zone, mapsRunZone, bestTime, damage / hp);
+	        if (debug > 0) {
+	        	System.out.format("Zone %d, ran %d maps, total time %.2f, dF=%.3f%n", zone, mapsRunZone, bestTime, damage / hp);
+	        }
         } else {
         	mapsRunZone = 0;
             double damage = damageMod * goldenBattleMod * eM.getTotalDamage()

--- a/src/TrimpsSimulation.java
+++ b/src/TrimpsSimulation.java
@@ -24,6 +24,7 @@ public class TrimpsSimulation {
     public final static double mapSize = 26;
     public final static double dropsPerMap = mapSize / 2d / 3d; // garden drop (1/3 metal) on 1/2 cells
     public final static double minerFraction = 0.99;
+    public final static double armorFraction = 0.01; // fraction of metal spent on armor
     public final static int packrat = 40;
     public final static boolean optimizeMaps = true; // true=optimize maps by doing test sims, false=use fixed grid based on damageFactor
     private final static double[] mapOffsets = new double[] { 100, 0.75, 0.5,
@@ -64,7 +65,7 @@ public class TrimpsSimulation {
         long times = System.nanoTime();
         int[] perks = new int[] {91,88,89,102,63100,44300,20300,55100,59,86,44};
         Perks p = new Perks(perks);
-        TrimpsSimulation tS = new TrimpsSimulation(PerksDeterminator.tsFactorsFromPerks(p), false,
+        TrimpsSimulation tS = new TrimpsSimulation(p.getTSFactors(), false,
                 //new AveragedZoneSimulation());
         		new ProbabilisticZoneModel(critChance, critDamage, okFactor));
         double highestHeHr = 0;
@@ -99,26 +100,33 @@ public class TrimpsSimulation {
     		final boolean useCache,
             final ZoneSimulation zoneSimulation) {
         this.useCache = useCache;
-        powMod = tsFactors[0];
-        motiMod = tsFactors[1];
-        popMod = tsFactors[2];
-        lootingMod = tsFactors[3];
-        coordFactor = tsFactors[4];
-        equipDiscount = tsFactors[5];
-        buildingDiscount = tsFactors[6];
+        powMod = tsFactors[Perks.tsFactor.POWER.ordinal()];
+        motiMod = tsFactors[Perks.tsFactor.MOTIVATION.ordinal()];
+        popMod = tsFactors[Perks.tsFactor.CARPENTRY.ordinal()];
+        lootingMod = tsFactors[Perks.tsFactor.LOOTING.ordinal()];
+        coordFactor = tsFactors[Perks.tsFactor.COORDINATED.ordinal()];
+        equipDiscount = tsFactors[Perks.tsFactor.ARTISANISTRY.ordinal()];
+        buildingDiscount = tsFactors[Perks.tsFactor.RESOURCEFUL.ordinal()];
         eM = new EquipmentManager(equipDiscount);
         pM = new PopulationManager(popMod, buildingDiscount, coordFactor);
         damageMod = achievementDamage
-                * 7 * 4 // anticipation * dominance
-                * robotrimpDamage * heirloomDamage
+                * 7 // anticipation
+                * 4 // dominance
+                * robotrimpDamage
+                * heirloomDamage
                 * powMod;
         storageFactor = 1 - 0.25 * buildingDiscount/(1 + packrat/5d); // storage costs eat into all resources
         metalMod = 0.5 // base per miner
         		* minerFraction * 0.5 // workspaces are half of population
-        		* heirloomMinerEff * turkimpMod
+        		* heirloomMinerEff
+        		* turkimpMod
+        		* (1 - armorFraction)
         		* storageFactor
                 * motiMod;
-        dropMod = 0.16 * heirloomMetalDrop * turkimpDropMod
+        dropMod = 0.16 // drops are based on 1/6 of population
+        		* heirloomMetalDrop
+        		* turkimpDropMod
+        		* (1 - armorFraction)
         		* storageFactor
                 * lootingMod;
         jCMod = metalMod
@@ -226,7 +234,7 @@ public class TrimpsSimulation {
 	        }
 	        time += bestTime;
 	        addProduction(bestZoneTime, dropsPerZone, 1);
-	        //System.out.format("Zone %d, ran %d maps, total time %.2f, dF=%.3f%n", zone, mapsRunZone, bestTime, dF);
+	        //System.out.format("Zone %d, ran %d maps, total time %.2f, dF=%.3f%n", zone, mapsRunZone, bestTime, damage / hp);
         } else {
         	mapsRunZone = 0;
             double damage = damageMod * goldenBattleMod * eM.getTotalDamage()


### PR DESCRIPTION
determinePerksPermute can be used to determine perks by permuting an existing set of perks based on testing stat effects. the original determinePerks sometimes gives better results at present. i think this is mostly because permutePerks doesn't yet account for redundant effects between related perks (especially carp & coord). so for example, if there is still significant benefit to be gained from additional coordinations, this will be reflected in the simulation efficiencies for both coord and carp, so both will be bought (with redundant effect). then for the next set of simulations, the efficiency of both will be very low (since they are overbought) so both will be sold. and we just oscillate between these two extremes instead of finding the happy middle ground that will give the best he/hr. my next project is to explicitly account for this redundancy in permutePerks.
